### PR TITLE
docs: prepare CHANGELOG for v1.0.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.4] - 2025-08-13
+
 ### Fixed
 - Fixed OpenAI API error: only use response_format for models that support it (not gpt-4o-mini)
 - Fixed commit message escaping to handle newlines and quotes in git commands


### PR DESCRIPTION
This PR prepares the CHANGELOG for the v1.0.4 release by moving the recently merged fixes from the "Unreleased" section to a versioned entry.

## Changes

- Move unreleased items to [1.0.4] - 2025-08-13
- Add empty Unreleased section for future changes

## Context

These fixes were just merged in PR #13 and resolve critical production issues:
- OpenAI API compatibility with gpt-4o-mini
- Git commit message escaping 
- Proper error handling and reporting

Following project policy, all releases require corresponding CHANGELOG entries.